### PR TITLE
Add gh-publish workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,5 +23,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: /JabMap
+          publish_dir: JabMap/
           force_orphan: true


### PR DESCRIPTION
Whenever there is a pull request or a push to main or dev, the current state is made availble at https://jabref.github.io/jabmap/.

One can manually trigger the workflow at https://github.com/JabRef/jabmap/actions/workflows/check.yml in case one needs another version published

Alternative: https://app.netlify.com/ - but this is more effort and might be confusing to newcomers.