### PR TITLE
Selection bugs fix

### DIFF
--- a/src/jsmind/src/jsmind.view_provider.js
+++ b/src/jsmind/src/jsmind.view_provider.js
@@ -505,12 +505,14 @@ export class ViewProvider {
             // Wrapping node's topic
             const maxTopicLength = 45;
             let topic = node.topic;
-            if (topic.length > maxTopicLength) {
-                topic = topic.slice(0, maxTopicLength - 1 - 3) + '...';
+            let applied_icons = node.data.icons || [];
+            if (topic.length + applied_icons.length > maxTopicLength) {
+                // The "5" = '...'.length + 2 chars for left-right padding
+                topic = topic.slice(0, maxTopicLength - 5 - applied_icons.length * 2) + '...';
             }
 
             // Building HTML <img> tags to attach to the node
-            let icons = (node.data.icons || [])
+            let icons = applied_icons
             .map(iconKey => `<img src="${this.resourceManager.TAG_ICONS[iconKey]}" style="width: 16px; height: 16px; margin-right: 2px; vertical-align: middle;">`)
             .join('');
             if (!!node.data.type && node.data.type !== 'Text') {

--- a/src/main.js
+++ b/src/main.js
@@ -113,7 +113,6 @@ const jm = new jsMind(options);
 jm.add_event_listener((type, data) => {
     if (type === jsMind.event_type.show) {
         addPopoversToBibEntryNodes();
-        jm.select_clear();
 
         redoBtn.disabled = !jm.actionStack.isRedoable;
         undoBtn.disabled = !jm.actionStack.isUndoable;

--- a/src/main.js
+++ b/src/main.js
@@ -89,13 +89,13 @@ options.shortcut.handles = {
         openBtn.onclick();
     },
     'addBibChild': function (jm, e) {
-        if (!jm.get_selected_node()) {
+        if (!jm.get_selected_node() || jm.get_selected_node().isroot) {
             return;
         }
         addBibEntryAsChildBtn.onclick();
     },
     'addPDFChild': function (jm, e) {
-        if (!jm.get_selected_node()) {
+        if (!jm.get_selected_node() || jm.get_selected_node().isroot) {
             return;
         }
         addPDFModalObject.toggle();
@@ -131,7 +131,7 @@ jm.add_event_listener((type, data) => {
         hidePopovers();
 
         // disable nodes' buttons, if no node's selected
-        let isNodeSelected = !!jm.get_selected_node();
+        let selectedNode = jm.get_selected_node();
         let buttons = [
             newChildBtn,
             newSiblingBtn,
@@ -139,7 +139,11 @@ jm.add_event_listener((type, data) => {
             BibEntryDropdownMenuButton,
             PDFDropDownMenuButton
         ];
-        toggleButtonsEnabled(buttons, isNodeSelected);
+        toggleButtonsEnabled(buttons, !!selectedNode);
+
+        if (selectedNode?.isroot) {
+            toggleButtonsEnabled([newSiblingBtn], false);
+        }
     }
 });
 
@@ -419,6 +423,11 @@ addBibEntryAsSiblingBtn.onclick = async function () {
         });
 }
 
+// disable siblings' option if root's selected
+BibEntryDropdownMenuButton.onclick = function () {
+    addBibEntryAsSiblingBtn.disabled = jm.get_selected_node()?.isroot;
+}
+
 //#endregion
 //#region [PDF Nodes]
 
@@ -503,6 +512,11 @@ addSelectedPDFBtn.onclick = function () {
     // save map state for undo/redo
     jm.saveState();
 };
+
+// disable siblings' option if root's selected
+PDFDropDownMenuButton.onclick = function () {
+    addPDFAsSiblingBtn.disabled = jm.get_selected_node()?.isroot;
+}
 
 //#endregion
 //#region [Icons & Tags]


### PR DESCRIPTION
## 📝Description
Here are some bug fixes related to nodes' selection.

## 👾 Performed Fixes
- Newly created child nodes don't lose their focus / selection (_just like sibling nodes_)
- Long topics are cut with respect to applied icons to fit the node's area
- The "Add as Sibling" buttons and shortcuts will be disabled, if the root node's selected

Closes #49 #32 #37 